### PR TITLE
Update package version to 1.1.4 in package.json and package-lock.json…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vite-plugin-src-update",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vite-plugin-src-update",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.13.3",

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Julboben/vite-src-update.git"
+    "url": "git+https://github.com/Julboben/vite-plugin-src-update.git"
   },
-  "homepage": "https://github.com/Julboben/vite-src-update#readme",
+  "homepage": "https://github.com/Julboben/vite-plugin-src-update#readme",
   "bugs": {
-    "url": "https://github.com/Julboben/vite-src-update/issues"
+    "url": "https://github.com/Julboben/vite-plugin-src-update/issues"
   },
   "keywords": [
     "vite",


### PR DESCRIPTION
…; correct repository URLs for consistency with new plugin name.